### PR TITLE
Specify python3 interpreter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ very huge graphs with a lot of noise.
 `Profile.dump_stats() <https://docs.python.org/3/library/profile.html#profile.Profile.dump_stats>`_
 call or via direct script profiling::
 
-    python -m cProfile -o myscript.prof myscript.py
+    python3 -m cProfile -o myscript.prof myscript.py
 
 
 Install
@@ -24,7 +24,7 @@ Via pip::
 
 Or you can invoke ``flameprof.py`` directly::
 
-    python flameprof.py input.prof > output.svg
+    python3 flameprof.py input.prof > output.svg
 
 
 Native svg (--format=svg)

--- a/bin/flameprof
+++ b/bin/flameprof
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec python -m flameprof "$@"
+exec python3 -m flameprof "$@"

--- a/flameprof.py
+++ b/flameprof.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 from __future__ import division, print_function
 
 import os.path


### PR DESCRIPTION
Specify interpreter as `python3` since that is the correct major version of python for this tool.

Closes #6